### PR TITLE
s/__hadoop_datanode_conf_dir/__hadoop_conf_dir/

### DIFF
--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -2,5 +2,5 @@ __hadoop_datanode_user: hdfs
 __hadoop_datanode_group: hadoop
 __hadoop_datanode_db_dir: /var/db/datanode
 __hadoop_datanode_service: datanode
-__hadoop_datanode_conf_dir: /usr/local/etc/hadoop
+__hadoop_conf_dir: /usr/local/etc/hadoop
 __hadoop_datanode_nodemanager_service: nodemanager


### PR DESCRIPTION
fixes "AnsibleUndefinedVariable: '__hadoop_conf_dir' is undefined" in
ansible-role-hadoop-namenode.
